### PR TITLE
Fix deletion logic and paths

### DIFF
--- a/perfil.php
+++ b/perfil.php
@@ -74,7 +74,7 @@ $stm->close();
               <td><?= date('d/m/Y', strtotime($mascota['fechadeextravio'])) ?></td>
               <td>
                 <a href="editar_mascota.php?id=<?= $mascota['id_mascota'] ?>" class="boton-contorno btn-tabla">Editar</a>
-                <a href="borrar_mascota.php?id=<?= $mascota['id_mascota'] ?>" class="boton-contorno btn-tabla" onclick="return confirm('¿Seguro que deseas eliminar la mascota?')">Eliminar</a>
+                <a href="php/borrar_mascota.php?id=<?= $mascota['id_mascota'] ?>" class="boton-contorno btn-tabla" onclick="return confirm('¿Seguro que deseas eliminar la mascota?')">Eliminar</a>
               </td>
             </tr>
           <?php endforeach; ?>

--- a/php/borrar_comentario.php
+++ b/php/borrar_comentario.php
@@ -21,10 +21,25 @@ if (!$comentario) {
     exit;
 }
 
-$stmt = $conexion->prepare("DELETE FROM comentario WHERE id_comentario = ?");
-$stmt->bind_param('i', $id_comentario);
-$stmt->execute();
 
-header("Location: ../detalle_mascota.php?id=$id_mascota");
+// Función recursiva para eliminar un comentario y todas sus respuestas
+function eliminarComentario($conexion, $id) {
+    // Primero elimina las respuestas de este comentario
+    $stmtHijos = $conexion->prepare("SELECT id_comentario FROM comentario WHERE id_responde = ?");
+    $stmtHijos->bind_param('i', $id);
+    $stmtHijos->execute();
+    $res = $stmtHijos->get_result();
+    while ($row = $res->fetch_assoc()) {
+        eliminarComentario($conexion, $row['id_comentario']);
+    }
+    // Ahora elimina el propio comentario
+    $stmtDel = $conexion->prepare("DELETE FROM comentario WHERE id_comentario = ?");
+    $stmtDel->bind_param('i', $id);
+    $stmtDel->execute();
+}
+
+eliminarComentario($conexion, $id_comentario);
+
+header("Location: ../detalle-mascota.php?id=$id_mascota");
 exit;
 ?>

--- a/php/borrar_mascota.php
+++ b/php/borrar_mascota.php
@@ -1,9 +1,9 @@
 <?php
 session_start();
-require 'php/conexion.php';
+require 'conexion.php';
 
 if (!isset($_SESSION['usuario_id'])) {
-    header('Location: login.php');
+    header('Location: ../login.php');
     exit;
 }
 
@@ -18,8 +18,31 @@ $result = $stmt->get_result();
 
 if ($result->num_rows == 0) {
     // Mascota no encontrada o no es del usuario
-    header("Location: perfil.php?errordelete=1");
+    header("Location: ../perfil.php?errordelete=1");
     exit;
+}
+
+// Función recursiva para eliminar comentarios y sus respuestas
+function eliminarComentario($conexion, $id) {
+    $stmtHijos = $conexion->prepare("SELECT id_comentario FROM comentario WHERE id_responde = ?");
+    $stmtHijos->bind_param('i', $id);
+    $stmtHijos->execute();
+    $res = $stmtHijos->get_result();
+    while ($row = $res->fetch_assoc()) {
+        eliminarComentario($conexion, $row['id_comentario']);
+    }
+    $stmtDel = $conexion->prepare("DELETE FROM comentario WHERE id_comentario = ?");
+    $stmtDel->bind_param('i', $id);
+    $stmtDel->execute();
+}
+
+// Obtener comentarios principales de la mascota y eliminarlos en cascada
+$stmtComentarios = $conexion->prepare("SELECT id_comentario FROM comentario WHERE id_mascota = ?");
+$stmtComentarios->bind_param('i', $id_mascota);
+$stmtComentarios->execute();
+$resComentarios = $stmtComentarios->get_result();
+while ($row = $resComentarios->fetch_assoc()) {
+    eliminarComentario($conexion, $row['id_comentario']);
 }
 
 // Elimina la mascota
@@ -27,6 +50,6 @@ $stmt = $conexion->prepare("DELETE FROM mascota WHERE id_mascota=? AND id_usuari
 $stmt->bind_param('ii', $id_mascota, $id_usuario);
 $stmt->execute();
 
-header("Location: perfil.php?borradomascota=1");
+header("Location: ../perfil.php?borradomascota=1");
 exit;
 ?>

--- a/php/editar_comentario.php
+++ b/php/editar_comentario.php
@@ -26,7 +26,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $stmt->bind_param('si', $nuevoComentario, $id_comentario);
     $stmt->execute();
 
-    header("Location: ../detalle_mascota.php?id=" . $comentario['id_mascota']);
+    header("Location: ../detalle-mascota.php?id=" . $comentario['id_mascota']);
     exit;
 }
 ?>
@@ -43,7 +43,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <form method="POST" class="formulario-comentario">
         <textarea name="comentario" required rows="4" style="width:100%;"><?= htmlspecialchars($comentario['comentario']) ?></textarea>
         <button type="submit" class="boton" style="margin-top:15px;">Guardar Cambios</button>
-        <a href="../detalle_mascota.php?id=<?= $comentario['id_mascota'] ?>" class="boton-contorno" style="margin-top:10px;">Cancelar</a>
+        <a href="../detalle-mascota.php?id=<?= $comentario['id_mascota'] ?>" class="boton-contorno" style="margin-top:10px;">Cancelar</a>
     </form>
 </div>
 </body>


### PR DESCRIPTION
## Summary
- fix URL after editing comments
- fix comment deletion to remove nested replies
- update delete pet script with cascade comment cleanup
- correct resource paths for deleting pets

## Testing
- `tests/run_tests.sh` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869f1a00b5883329b57cc44f6de4a29